### PR TITLE
Add GPIO relay reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ WantedBy=multi-user.target
 ## Testing
 Run tests with `pytest`.
 Use `scripts/cycle_relay.py <rig>` to manually trigger a relay.
+
+### API
+`POST /power/reboot/{rig_name}` will pulse the GPIO relay assigned to the rig's
+reset header for the configured duration. Each action is recorded in
+`data/duckdb/power.duckdb`.

--- a/config/relays.yaml
+++ b/config/relays.yaml
@@ -1,6 +1,18 @@
 rig1:
   pin: 17
-  pulse_seconds: 2
+  pulse_seconds: 1
 rig2:
   pin: 27
-  pulse_seconds: 2
+  pulse_seconds: 1
+rig3:
+  pin: 22
+  pulse_seconds: 1
+rig4:
+  pin: 5
+  pulse_seconds: 1
+rig5:
+  pin: 6
+  pulse_seconds: 1
+rig6:
+  pin: 13
+  pulse_seconds: 1

--- a/config/rigs.yaml
+++ b/config/rigs.yaml
@@ -1,2 +1,6 @@
 rig1: RIG_ID_1
 rig2: RIG_ID_2
+rig3: RIG_ID_3
+rig4: RIG_ID_4
+rig5: RIG_ID_5
+rig6: RIG_ID_6

--- a/occulis_server/main.py
+++ b/occulis_server/main.py
@@ -43,7 +43,7 @@ async def root(token: HTTPAuthorizationCredentials = Depends(verify_token)):
 
 @app.post("/power/reboot/{rig_name}")
 async def reboot_rig(rig_name: str, token: HTTPAuthorizationCredentials = Depends(verify_token)):
-    if not power.cycle_relay(rig_name):
+    if not power.trigger_relay(rig_name):
         raise HTTPException(status_code=404, detail="Rig not found")
-    return {"status": "reboot_triggered", "rig": rig_name}
+    return {"status": f"{rig_name} reset triggered via relay."}
 

--- a/occulis_server/power_control.py
+++ b/occulis_server/power_control.py
@@ -1,5 +1,7 @@
 import yaml
 import time
+import duckdb
+from datetime import datetime
 try:
     from gpiozero import OutputDevice
 except ImportError:  # for development without GPIO
@@ -19,15 +21,28 @@ def load_relays(path):
 class PowerController:
     def __init__(self, relays_path: str):
         self.relays_config = load_relays(relays_path)
-        self.relays = {name: OutputDevice(cfg['pin'], active_high=True, initial_value=False)
-                       for name, cfg in self.relays_config.items()}
+        self.relays = {
+            name: OutputDevice(cfg['pin'], active_high=False, initial_value=True)
+            for name, cfg in self.relays_config.items()
+        }
+        self.db = duckdb.connect('data/duckdb/power.duckdb')
+        self.db.execute(
+            "CREATE TABLE IF NOT EXISTS relay_log (timestamp TIMESTAMP, rig TEXT, pin INTEGER)"
+        )
 
     def cycle_relay(self, rig_name: str) -> bool:
+        return self.trigger_relay(rig_name)
+
+    def trigger_relay(self, rig_name: str) -> bool:
         cfg = self.relays_config.get(rig_name)
         relay = self.relays.get(rig_name)
         if not cfg or not relay:
             return False
         relay.on()
-        time.sleep(cfg.get('pulse_seconds', 2))
+        time.sleep(cfg.get('pulse_seconds', 1))
         relay.off()
+        self.db.execute(
+            "INSERT INTO relay_log VALUES (?, ?, ?)",
+            [datetime.utcnow(), rig_name, cfg['pin']],
+        )
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ jinja2
 schedule
 pyyaml
 uvicorn
-smtplib
-nginx
+pytest-asyncio

--- a/scripts/cycle_relay.py
+++ b/scripts/cycle_relay.py
@@ -7,5 +7,5 @@ if __name__ == '__main__':
         print('Usage: cycle_relay.py <rig_name>')
         sys.exit(1)
     pc = PowerController('config/relays.yaml')
-    if not pc.cycle_relay(sys.argv[1]):
+    if not pc.trigger_relay(sys.argv[1]):
         print('Unknown rig')

--- a/tests/test_power_control.py
+++ b/tests/test_power_control.py
@@ -1,0 +1,17 @@
+import os
+import duckdb
+from occulis_server.power_control import PowerController
+
+
+def test_trigger_relay_logs(tmp_path, monkeypatch):
+    os.environ["GPIOZERO_PIN_FACTORY"] = "mock"
+    db_path = tmp_path / "power.duckdb"
+    pc = PowerController('config/relays.yaml')
+    # redirect database to temp path for test
+    pc.db.close()
+    pc.db = duckdb.connect(str(db_path))
+    pc.db.execute("CREATE TABLE IF NOT EXISTS relay_log (timestamp TIMESTAMP, rig TEXT, pin INTEGER)")
+    pc.trigger_relay('rig1')
+    rows = pc.db.execute("SELECT rig, pin FROM relay_log").fetchall()
+    assert ('rig1', 17) in rows
+


### PR DESCRIPTION
## Summary
- add new trigger_relay method with DuckDB logging
- expose reboot endpoint using trigger_relay
- document new endpoint in README
- expand relay configuration for six rigs
- add unit test for trigger_relay
- update dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687591801950832684684134d8c461ac