### PR TITLE
Add Raspberry Pi display status screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Use `scripts/cycle_relay.py <rig>` to manually trigger a relay.
 `POST /power/reboot/{rig_name}` will pulse the GPIO relay assigned to the rig's
 reset header for the configured duration. Each action is recorded in
 `data/duckdb/power.duckdb`.
+
+## Display Status Screen
+A simple Tkinter interface can show current rig statistics on a Raspberry Pi 7" display. It is independent of the FastAPI dashboard and won't interfere with other monitoring tools. Launch it with:
+
+```bash
+python scripts/display_status.py [--host localhost] [--port 6379] [--interval 5000]
+```
+
+The script polls Redis for rig data and updates the screen every few seconds. Redis connection parameters can also be provided via the environment variables `OCCULIS_REDIS_HOST` and `OCCULIS_REDIS_PORT`.

--- a/occulis_server/display.py
+++ b/occulis_server/display.py
@@ -1,0 +1,65 @@
+import tkinter as tk
+import os
+import redis
+from typing import Dict
+
+
+class StatusDisplay:
+    """Simple Tkinter GUI to show rig statistics on a small display.
+
+    Parameters
+    ----------
+    redis_host : str
+        Hostname for the Redis server.
+    redis_port : int
+        Port of the Redis server.
+    refresh_interval : int
+        Polling interval in milliseconds.
+    """
+
+    def __init__(self, redis_host: str = 'localhost', redis_port: int = 6379,
+                 refresh_interval: int = 5000):
+        redis_host = os.getenv('OCCULIS_REDIS_HOST', redis_host)
+        redis_port = int(os.getenv('OCCULIS_REDIS_PORT', redis_port))
+        self.redis = redis.Redis(host=redis_host, port=redis_port, db=0)
+        self.root = tk.Tk()
+        self.root.title("Occulis Status")
+        self.labels: Dict[str, tk.Label] = {}
+        # typical resolution of the official 7" touchscreen
+        self.root.geometry("800x480")
+        self.refresh_interval = refresh_interval
+
+    def _fetch_stats(self) -> Dict[str, Dict[str, str]]:
+        """Retrieve rig stats from Redis using scan_iter to avoid blocking."""
+        data: Dict[str, Dict[str, str]] = {}
+        for key in self.redis.scan_iter():
+            name = key.decode("utf-8")
+            stats = {
+                k.decode("utf-8"): v.decode("utf-8")
+                for k, v in self.redis.hgetall(key).items()
+            }
+            data[name] = stats
+        return data
+
+    def _update_labels(self) -> None:
+        """Refresh labels with the latest rig statistics."""
+        stats = self._fetch_stats()
+        for name, rig_stats in sorted(stats.items()):
+            temp = rig_stats.get('temp', '?')
+            hashrate = rig_stats.get('hashrate', '?')
+            text = f"{name}: {temp}C, {hashrate}H/s"
+            if name not in self.labels:
+                lbl = tk.Label(self.root, text=text, font=("Helvetica", 20))
+                lbl.pack(anchor='w')
+                self.labels[name] = lbl
+            else:
+                self.labels[name].config(text=text)
+        self.root.after(self.refresh_interval, self._update_labels)
+
+    def run(self):
+        self._update_labels()
+        self.root.mainloop()
+
+
+if __name__ == "__main__":
+    StatusDisplay().run()

--- a/scripts/display_status.py
+++ b/scripts/display_status.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Launch the Tkinter status display."""
+import argparse
+from occulis_server.display import StatusDisplay
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show mining rig status")
+    parser.add_argument("--host", default="localhost", help="Redis hostname")
+    parser.add_argument("--port", type=int, default=6379, help="Redis port")
+    parser.add_argument("--interval", type=int, default=5000,
+                        help="Refresh interval in ms")
+    args = parser.parse_args()
+    StatusDisplay(args.host, args.port, args.interval).run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Tkinter-based status display that polls redis for rig data
- expose the display via `scripts/display_status.py`
- document how to launch the display in the README
- use `scan_iter` for redis polling
- allow host/port and interval to be configured via env vars or CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687679c94de08326972b513eaafa3ef2