### PR TITLE
Decode redis values in root endpoint

### DIFF
--- a/occulis_server/main.py
+++ b/occulis_server/main.py
@@ -37,7 +37,13 @@ async def startup_event():
 
 @app.get("/")
 async def root(token: HTTPAuthorizationCredentials = Depends(verify_token)):
-    rigs = [redis_client.hgetall(rig).decode('utf-8') for rig in redis_client.keys()]
+    rigs = {
+        key.decode("utf-8"): {
+            k.decode("utf-8"): v.decode("utf-8")
+            for k, v in redis_client.hgetall(key).items()
+        }
+        for key in redis_client.keys()
+    }
     return {"rigs": rigs}
 
 

--- a/tests/test_root_endpoint.py
+++ b/tests/test_root_endpoint.py
@@ -1,0 +1,33 @@
+import os
+import importlib
+import sys
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+
+@pytest.mark.asyncio
+async def test_root_decodes(monkeypatch):
+    os.environ["GPIOZERO_PIN_FACTORY"] = "mock"
+
+    # Stub PowerController before importing main module to avoid GPIO usage
+    class DummyPC:
+        def __init__(self, *args, **kwargs):
+            pass
+    pc_module = importlib.import_module('occulis_server.power_control')
+    monkeypatch.setattr(pc_module, 'PowerController', DummyPC)
+
+    main_module = importlib.import_module('occulis_server.main')
+
+    class DummyRedis:
+        def __init__(self):
+            self.store = {b'rig1': {b'temp': b'75', b'hashrate': b'100'}}
+        def keys(self):
+            return list(self.store.keys())
+        def hgetall(self, key):
+            return self.store[key]
+    dummy = DummyRedis()
+    monkeypatch.setattr(main_module, 'redis_client', dummy)
+
+    token = HTTPAuthorizationCredentials(scheme="Bearer", credentials=main_module.API_TOKEN)
+    result = await main_module.root(token)
+    assert result == {'rigs': {'rig1': {'temp': '75', 'hashrate': '100'}}}


### PR DESCRIPTION
## Summary
- decode redis data properly in `root` endpoint
- add regression test for the endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f5d0d4448326ae7bbb120a39e86e