### PR TITLE
Add Hashmancer API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .env
 config/secrets.env
+data/duckdb/power.duckdb

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Occulis is a Raspberry Pi based manager for NiceHash OS rigs. It polls the NiceH
 ## Setup
 1. Install dependencies: `pip install -r requirements.txt`
 2. Configure rigs and relays in `config/rigs.yaml` and `config/relays.yaml`.
-3. Add NiceHash and email credentials in `config/secrets.env`.
-4. Run with `uvicorn occulis_server.main:app --host 0.0.0.0 --port 8000`
+3. Configure Hashmancer workers in `config/hashmancer_workers.yaml`.
+4. Add NiceHash, Hashmancer, and email credentials in `config/secrets.env`.
+5. Run with `uvicorn occulis_server.main:app --host 0.0.0.0 --port 8000`
 
 ## Systemd Service
 An example systemd unit:
@@ -42,3 +43,7 @@ python scripts/display_status.py [--host localhost] [--port 6379] [--interval 50
 ```
 
 The script polls Redis for rig data and updates the screen every few seconds. Redis connection parameters can also be provided via the environment variables `OCCULIS_REDIS_HOST` and `OCCULIS_REDIS_PORT`.
+
+### Environment Variables
+* `HM_API_URL` - base URL for Hashmancer's FastAPI (default `http://localhost:8001`).
+* `HM_API_TOKEN` - optional bearer token for authenticated requests.

--- a/config/hashmancer_workers.yaml
+++ b/config/hashmancer_workers.yaml
@@ -1,0 +1,6 @@
+worker1: WORKER_ID_1
+worker2: WORKER_ID_2
+worker3: WORKER_ID_3
+worker4: WORKER_ID_4
+worker5: WORKER_ID_5
+worker6: WORKER_ID_6

--- a/occulis_server/hashmancer_api.py
+++ b/occulis_server/hashmancer_api.py
@@ -1,0 +1,43 @@
+import os
+import asyncio
+import httpx
+import yaml
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join('config', 'secrets.env'))
+
+API_URL = os.getenv('HM_API_URL', 'http://localhost:8001')
+API_TOKEN = os.getenv('HM_API_TOKEN')
+
+
+class HashmancerAPI:
+    def __init__(self):
+        headers = {}
+        if API_TOKEN:
+            headers['Authorization'] = f'Bearer {API_TOKEN}'
+        self.client = httpx.AsyncClient(base_url=API_URL, headers=headers)
+
+    async def get(self, path: str, params=None):
+        resp = await self.client.get(path, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def post(self, path: str, json=None):
+        resp = await self.client.post(path, json=json)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def poll_loop(self, workers_config: str, redis_client):
+        with open(workers_config, 'r') as f:
+            workers = yaml.safe_load(f) or {}
+        while True:
+            for name, worker_id in workers.items():
+                try:
+                    stats = await self.get(f'/workers/{worker_id}/stats')
+                    redis_client.hset(name, mapping=stats)
+                except Exception as e:
+                    redis_client.hset(name, mapping={'error': str(e)})
+            await asyncio.sleep(30)
+
+    async def reboot_worker(self, worker_id: str):
+        await self.post(f'/workers/{worker_id}/reboot')

--- a/occulis_server/rules_engine.py
+++ b/occulis_server/rules_engine.py
@@ -5,9 +5,10 @@ from typing import Dict, Any
 
 
 class RulesEngine:
-    def __init__(self, rules_path: str, api, power, notifier, redis_client):
+    def __init__(self, rules_path: str, api, power, notifier, redis_client, hashmancer_api=None):
         self.rules_path = rules_path
         self.api = api
+        self.hm_api = hashmancer_api
         self.power = power
         self.notifier = notifier
         self.redis = redis_client
@@ -46,6 +47,8 @@ class RulesEngine:
         for act in actions:
             if act == 'api.reboot':
                 await self.api.reboot_rig(rig_name)
+            elif act == 'hashmancer.reboot' and self.hm_api:
+                await self.hm_api.reboot_worker(rig_name)
             elif act == 'power.gpio_cycle':
                 self.power.cycle_relay(rig_name)
             elif act == 'notify.email':

--- a/tests/test_hashmancer_mock.py
+++ b/tests/test_hashmancer_mock.py
@@ -1,0 +1,26 @@
+import asyncio
+import pytest
+from occulis_server.hashmancer_api import HashmancerAPI
+
+class MockClient:
+    async def get(self, path, params=None):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'fan': '80'}
+        return Resp()
+
+@pytest.mark.asyncio
+async def test_poll_loop(monkeypatch):
+    api = HashmancerAPI()
+    monkeypatch.setattr(api, 'client', MockClient())
+    redis = {}
+    class Redis:
+        def hset(self, name, mapping):
+            redis[name] = mapping
+    r = Redis()
+    task = asyncio.create_task(api.poll_loop('config/hashmancer_workers.yaml', r))
+    await asyncio.sleep(0.1)
+    task.cancel()
+    assert 'worker1' in redis

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -27,3 +27,19 @@ async def test_rule_trigger():
     notif = Notifier()
     engine = RulesEngine('config/rules.yaml', DummyAPI(), power, notif, DummyRedis())
     await run_once(engine)
+
+class DummyHM:
+    def __init__(self):
+        self.called = False
+    async def reboot_worker(self, worker_id):
+        self.called = True
+
+@pytest.mark.asyncio
+async def test_hashmancer_action(monkeypatch):
+    os.environ["GPIOZERO_PIN_FACTORY"] = "mock"
+    power = PowerController('config/relays.yaml')
+    notif = Notifier()
+    hm = DummyHM()
+    engine = RulesEngine('config/rules.yaml', DummyAPI(), power, notif, DummyRedis(), hm)
+    await engine.execute_actions(['hashmancer.reboot'], 'rig1')
+    assert hm.called


### PR DESCRIPTION
## Summary
- implement `HashmancerAPI` for interacting with Hashmancer FastAPI
- support new `hashmancer.reboot` action in `RulesEngine`
- poll Hashmancer workers from `main.py`
- document new setup step and environment variables
- provide config example for Hashmancer workers
- add tests for Hashmancer API and RulesEngine integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f85ca5588326bd255666d50d7d1d