### PR TITLE
Fix rule condition variable and verify trigger

### DIFF
--- a/config/hashmancer_workers.yaml
+++ b/config/hashmancer_workers.yaml
@@ -1,0 +1,6 @@
+worker1: WORKER_ID_1
+worker2: WORKER_ID_2
+worker3: WORKER_ID_3
+worker4: WORKER_ID_4
+worker5: WORKER_ID_5
+worker6: WORKER_ID_6

--- a/config/relays.yaml
+++ b/config/relays.yaml
@@ -1,0 +1,18 @@
+rig1:
+  pin: 17
+  pulse_seconds: 1
+rig2:
+  pin: 27
+  pulse_seconds: 1
+rig3:
+  pin: 22
+  pulse_seconds: 1
+rig4:
+  pin: 5
+  pulse_seconds: 1
+rig5:
+  pin: 6
+  pulse_seconds: 1
+rig6:
+  pin: 13
+  pulse_seconds: 1

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -1,5 +1,5 @@
 - rig: rig1
-  condition: "int(stats['temp']) > 85"
+  condition: "int(temp) > 85"
   duration: 300
   actions:
     - power.gpio_cycle


### PR DESCRIPTION
## Summary
- update `rules.yaml` to use `temp` variable from rig data
- add missing config used by tests
- assert rules trigger and close GPIO pins in tests
- expect mapping dictionary from API reboot test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688504edabcc832693d71de86d4732c4