### PR TITLE
Refactor relay control to async

### DIFF
--- a/occulis_server/main.py
+++ b/occulis_server/main.py
@@ -59,7 +59,7 @@ async def root(token: HTTPAuthorizationCredentials = Depends(verify_token)):
 
 @app.post("/power/reboot/{rig_name}")
 async def reboot_rig(rig_name: str, token: HTTPAuthorizationCredentials = Depends(verify_token)):
-    if not power.trigger_relay(rig_name):
+    if not await power.trigger_relay(rig_name):
         raise HTTPException(status_code=404, detail="Rig not found")
     return {"status": f"{rig_name} reset triggered via relay."}
 

--- a/occulis_server/power_control.py
+++ b/occulis_server/power_control.py
@@ -1,5 +1,5 @@
 import yaml
-import time
+import asyncio
 import duckdb
 from datetime import datetime
 try:
@@ -38,16 +38,16 @@ class PowerController:
             "CREATE TABLE IF NOT EXISTS relay_log (timestamp TIMESTAMP, rig TEXT, pin INTEGER)"
         )
 
-    def cycle_relay(self, rig_name: str) -> bool:
-        return self.trigger_relay(rig_name)
+    async def cycle_relay(self, rig_name: str) -> bool:
+        return await self.trigger_relay(rig_name)
 
-    def trigger_relay(self, rig_name: str) -> bool:
+    async def trigger_relay(self, rig_name: str) -> bool:
         cfg = self.relays_config.get(rig_name)
         relay = self.relays.get(rig_name)
         if not cfg or not relay:
             return False
         relay.on()
-        time.sleep(cfg.get('pulse_seconds', 1))
+        await asyncio.sleep(cfg.get('pulse_seconds', 1))
         relay.off()
         self.db.execute(
             "INSERT INTO relay_log VALUES (?, ?, ?)",

--- a/occulis_server/rules_engine.py
+++ b/occulis_server/rules_engine.py
@@ -65,6 +65,6 @@ class RulesEngine:
                 worker_id = self.worker_map.get(rig_name, rig_name)
                 await self.hm_api.reboot_worker(worker_id)
             elif act == 'power.gpio_cycle':
-                self.power.cycle_relay(rig_name)
+                await self.power.cycle_relay(rig_name)
             elif act == 'notify.email':
                 self.notifier.send_email(f"Rule triggered for {rig_name}")

--- a/scripts/cycle_relay.py
+++ b/scripts/cycle_relay.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import asyncio
 from occulis_server.power_control import PowerController
 
 if __name__ == '__main__':
@@ -7,5 +8,5 @@ if __name__ == '__main__':
         print('Usage: cycle_relay.py <rig_name>')
         sys.exit(1)
     pc = PowerController('config/rigs.yaml')
-    if not pc.trigger_relay(sys.argv[1]):
+    if not asyncio.run(pc.trigger_relay(sys.argv[1])):
         print('Unknown rig')

--- a/tests/test_power_control.py
+++ b/tests/test_power_control.py
@@ -1,9 +1,11 @@
 import os
 import duckdb
+import pytest
 from occulis_server.power_control import PowerController
 
 
-def test_trigger_relay_logs(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_trigger_relay_logs(tmp_path, monkeypatch):
     os.environ["GPIOZERO_PIN_FACTORY"] = "mock"
     db_path = tmp_path / "power.duckdb"
     pc = PowerController('config/rigs.yaml')
@@ -11,7 +13,7 @@ def test_trigger_relay_logs(tmp_path, monkeypatch):
     pc.db.close()
     pc.db = duckdb.connect(str(db_path))
     pc.db.execute("CREATE TABLE IF NOT EXISTS relay_log (timestamp TIMESTAMP, rig TEXT, pin INTEGER)")
-    pc.trigger_relay('rig1')
+    await pc.trigger_relay('rig1')
     rows = pc.db.execute("SELECT rig, pin FROM relay_log").fetchall()
     assert ('rig1', 17) in rows
 


### PR DESCRIPTION
## Summary
- use `asyncio.sleep` in `PowerController.trigger_relay`
- await power actions in `RulesEngine.execute_actions`
- adjust API endpoint and helper script for async relay control
- update power controller tests for asyncio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68850a757a0c8326a8a6fb8eb46f1bf8